### PR TITLE
getTestResultAction() has been deprecated, implemented with the new getAction(Class) method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.podio</groupId>
 	<artifactId>podio-build-notifier</artifactId>
 	<name>Podio Build Notifier</name>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 	<packaging>hpi</packaging>
 
 	<!-- get every artifact through maven.glassfish.org, which proxies all the

--- a/src/main/java/com/podio/hudson/PodioBuildNotifier.java
+++ b/src/main/java/com/podio/hudson/PodioBuildNotifier.java
@@ -107,7 +107,7 @@ public class PodioBuildNotifier extends Notifier {
 
 		Integer totalTestCases = null;
 		Integer failedTestCases = null;
-		AbstractTestResultAction testResult = build.getTestResultAction();
+		AbstractTestResultAction testResult = build.getAction(AbstractTestResultAction.class);
 		if (testResult != null) {
 			totalTestCases = testResult.getTotalCount();
 			failedTestCases = testResult.getFailCount();
@@ -208,11 +208,11 @@ public class PodioBuildNotifier extends Notifier {
 		fields.add(new FieldValuesUpdate("developers", subValues));
 		if (totalTestCases != null) {
 			fields.add(new FieldValuesUpdate("total-testcases", "value",
-					totalTestCases));
+					Integer.toString(totalTestCases)));
 		}
 		if (failedTestCases != null) {
 			fields.add(new FieldValuesUpdate("failed-testcases", "value",
-					failedTestCases));
+                    Integer.toString(failedTestCases)));
 		}
 		fields.add(new FieldValuesUpdate("duration", "value", duration));
 		ItemCreate create = new ItemCreate(Integer.toString(buildNumber),


### PR DESCRIPTION
Hi.

Fixed this issue, along with some other issues mainly type conversions. Feel free to pull these changes as they now work with Jenkins again.
